### PR TITLE
Change "comma-dangle" rule to "never"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1469,7 +1469,7 @@
     const story = [
       once,
       upon,
-      aTime,
+      aTime
     ];
 
     // bad
@@ -1485,42 +1485,15 @@
       firstName: 'Ada',
       lastName: 'Lovelace',
       birthYear: 1815,
-      superPower: 'computers',
+      superPower: 'computers'
     };
     ```
 
-  - [19.2](#19.2) <a name='19.2'></a> Additional trailing comma: **Yup.**
-
-  > Why? This leads to cleaner git diffs. Also, transpilers like Babel will remove the additional trailing comma in the transpiled code which means you don't have to worry about the [trailing comma problem](es5/README.md#commas) in legacy browsers.
+  - [19.2](#19.2) <a name='19.2'></a> Additional trailing comma: **Nope.**
 
     ```javascript
-    // bad - git diff without trailing comma
-    const hero = {
-         firstName: 'Florence',
-    -    lastName: 'Nightingale'
-    +    lastName: 'Nightingale',
-    +    inventorOf: ['coxcomb graph', 'modern nursing']
-    }
-
-    // good - git diff with trailing comma
-    const hero = {
-         firstName: 'Florence',
-         lastName: 'Nightingale',
-    +    inventorOf: ['coxcomb chart', 'modern nursing'],
-    }
 
     // bad
-    const hero = {
-      firstName: 'Dana',
-      lastName: 'Scully'
-    };
-
-    const heroes = [
-      'Batman',
-      'Superman'
-    ];
-
-    // good
     const hero = {
       firstName: 'Dana',
       lastName: 'Scully',
@@ -1529,6 +1502,17 @@
     const heroes = [
       'Batman',
       'Superman',
+    ];
+
+    // good
+    const hero = {
+      firstName: 'Dana',
+      lastName: 'Scully'
+    };
+
+    const heroes = [
+      'Batman',
+      'Superman'
     ];
     ```
 

--- a/packages/eslint-config-libertyglobal/.eslintrc
+++ b/packages/eslint-config-libertyglobal/.eslintrc
@@ -52,7 +52,7 @@
 /**
  * Possible errors
  */
-    "comma-dangle": [2, "always-multiline"],    // http://eslint.org/docs/rules/comma-dangle
+    "comma-dangle": [2, "never"],    // http://eslint.org/docs/rules/comma-dangle
     "no-cond-assign": [2, "always"], // http://eslint.org/docs/rules/no-cond-assign
     "no-console": 1,                 // http://eslint.org/docs/rules/no-console
     "no-debugger": 1,                // http://eslint.org/docs/rules/no-debugger


### PR DESCRIPTION
``` javascript
{
  a: 1,
  b: 2,  // will be considered violation
}
```

Although I understand the [point of guys from airbnb](https://github.com/LibertyGlobal/javascript/compare/master...LibertyGlobal:feature/comma-dangle-never?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8L1494) this rule looks a bit exotic to our projects. But I would like to hear the opinion of other team members. 
